### PR TITLE
Quack 컴포넌트 Modifier 제공

### DIFF
--- a/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/GridLayoutPlayground.kt
+++ b/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/GridLayoutPlayground.kt
@@ -10,12 +10,15 @@ package team.duckie.quackquack.playground.realworld
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,7 +36,10 @@ import team.duckie.quackquack.playground.theme.PlaygroundTheme
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackBody1
 import team.duckie.quackquack.ui.component.QuackCardImage
+import team.duckie.quackquack.ui.component.QuackFooterGridLayout
+import team.duckie.quackquack.ui.component.QuackHeaderGridLayout
 import team.duckie.quackquack.ui.component.QuackIconToggle
+import team.duckie.quackquack.ui.component.QuackImage
 import team.duckie.quackquack.ui.component.QuackSelectableImage
 import team.duckie.quackquack.ui.component.QuackSimpleGridLayout
 import team.duckie.quackquack.ui.component.QuackTitle2
@@ -46,7 +52,9 @@ class GridLayoutPlayground : BaseActivity() {
     @Suppress("RemoveExplicitTypeArguments")
     private val items = persistentListOf<Pair<String, @Composable () -> Unit>>(
         "QuackGridLayout" to { QuackGridLayoutDemo() },
-        "QuackSelectableGridLayout" to { QuackSelectableGridLayoutDemo()},
+        "QuackSelectableGridLayout" to { QuackSelectableGridLayoutDemo() },
+        "QuackHeaderGridLayout" to { QuackHeaderGridLayoutDemo() },
+        "QuackFooterGridLayout" to { QuackFooterGridLayoutDemo() },
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -116,7 +124,7 @@ fun DuckieFavoriteItem(
 }
 
 @Composable
-fun QuackSelectableGridLayoutDemo(){
+fun QuackSelectableGridLayoutDemo() {
     val images = Array(
         size = 20,
     ) { "https://picsum.photos/id/237/200/300" }
@@ -143,11 +151,14 @@ fun QuackSelectableGridLayoutDemo(){
                 bottom = 30.dp,
             ),
         ) { index, item ->
-            val backgroundColor = if ( index % 2 == 0) QuackColor.SkyBlueColor else QuackColor.DuckieOrange
+            val backgroundColor =
+                if (index % 2 == 0) QuackColor.SkyBlueColor else QuackColor.DuckieOrange
             Box(
-                modifier = Modifier.fillMaxSize().background(
-                    color = backgroundColor.composeColor,
-                ),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        color = backgroundColor.composeColor,
+                    ),
                 contentAlignment = Alignment.Center,
             ) {
                 GalleryImageItem(
@@ -161,6 +172,7 @@ fun QuackSelectableGridLayoutDemo(){
         }
     }
 }
+
 @Composable
 private fun GalleryImageItem(
     isSelected: Boolean,
@@ -175,6 +187,83 @@ private fun GalleryImageItem(
         },
     )
 }
+
+@Composable
+fun QuackHeaderGridLayoutDemo() {
+
+    val images = Array(
+        size = 20,
+    ) { "https://picsum.photos/id/237/200/300" }
+    var selectedIndex by remember { mutableStateOf(-1) }
+
+    QuackHeaderGridLayout(
+        columns = 3,
+        items = images.toList().toPersistentList(),
+        horizontalSpace = 1.5.dp,
+        verticalSpace = 1.5.dp,
+        contentPadding = PaddingValues(
+            start = 8.dp,
+            end = 8.dp,
+            bottom = 30.dp,
+        ),
+        header = {
+            CameraIcon()
+        },
+        onClickHeader = {},
+        itemContent = { index, item ->
+            GalleryImageItem(
+                image = item,
+                onClick = {
+                    selectedIndex = index
+                },
+                isSelected = index == selectedIndex,
+            )
+        },
+    )
+}
+@Composable
+fun QuackFooterGridLayoutDemo() {
+
+    val images = Array(
+        size = 20,
+    ) { "https://picsum.photos/id/237/200/300" }
+    var selectedIndex by remember { mutableStateOf(-1) }
+
+    QuackFooterGridLayout(
+        columns = 3,
+        items = images.toList().toPersistentList(),
+        horizontalSpace = 1.5.dp,
+        verticalSpace = 1.5.dp,
+        contentPadding = PaddingValues(
+            start = 8.dp,
+            end = 8.dp,
+            bottom = 60.dp,
+        ),
+        footer = {
+            CameraIcon()
+        },
+        onClickFooter = {},
+        itemContent = { index, item ->
+            GalleryImageItem(
+                image = item,
+                onClick = {
+                    selectedIndex = index
+                },
+                isSelected = index == selectedIndex,
+            )
+        },
+    )
+}
+
+
+@Composable
+private fun CameraIcon(
+) {
+    QuackImage(
+        src = QuackIcon.Camera,
+    )
+}
+
 data class FavoriteItem(
     val title: String = "덕딜 어쩌구 제목이 길면 뭔가 달라지는 것 같은 느낌적인 느낌",
     val price: String = "69000원",

--- a/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/NavigationPlayground.kt
+++ b/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/NavigationPlayground.kt
@@ -141,10 +141,10 @@ private fun DropDown() {
         Row(
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            this@Box.QuackBody1(
+            QuackBody1(
                 text = "body1",
             )
-            this@Box.QuackImage(
+            QuackImage(
                 src = QuackIcon.ArrowDown,
                 overrideSize = DpSize(
                     width = 24.dp,

--- a/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/TypoPlayground.kt
+++ b/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/TypoPlayground.kt
@@ -19,8 +19,9 @@ import team.duckie.quackquack.playground.base.BaseActivity
 import team.duckie.quackquack.playground.base.PlaygroundSection
 import team.duckie.quackquack.playground.theme.PlaygroundTheme
 import team.duckie.quackquack.ui.color.QuackColor
-import team.duckie.quackquack.ui.component.QuackHighlightBody3
-import team.duckie.quackquack.ui.component.QuackHighlightHeadLine2
+import team.duckie.quackquack.ui.component.QuackHighlightBody1
+import team.duckie.quackquack.ui.component.QuackUnderlineBody3
+import team.duckie.quackquack.ui.component.QuackUnderlineHeadLine2
 
 class TypoPlayground : BaseActivity() {
     @Suppress("RemoveExplicitTypeArguments")
@@ -50,19 +51,27 @@ fun QuackHighlightTextDemo() {
             space = 10.dp,
         ),
     ) {
-        QuackHighlightHeadLine2(
+        QuackUnderlineHeadLine2(
             text = text,
-            highlightTextList = persistentListOf("우주사령관"),
+            underlineText = persistentListOf("우주사령관"),
             onClick = {},
         )
-        QuackHighlightBody3(
+        QuackUnderlineBody3(
             text = "가입 시, 덕키의 필수 이용 약관과\n개인정보 수집 및 이용에 동의하게 됩니다.",
-            highlightTextList = persistentListOf(
+            underlineText = persistentListOf(
                 "필수 이용 약관",
                 "개인정보 수집 및 이용",
             ),
             color = QuackColor.Gray2,
-            highlightColor = QuackColor.Gray2,
+            undelineTextColor = QuackColor.Gray2,
+            align = TextAlign.Center,
+        )
+        QuackHighlightBody1(
+            text = "가입 시, 덕키의 필수 이용 약관과\n개인정보 수집 및 이용에 동의하게 됩니다.",
+            highlightText = persistentListOf(
+                "필수 이용 약관",
+                "개인정보 수집 및 이용",
+            ),
             align = TextAlign.Center,
         )
     }

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/button.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/button.kt
@@ -408,7 +408,7 @@ private fun QuackBasicButton(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center,
         ) {
-            this@QuackSurface.QuackImage(
+            QuackImage(
                 src = leadingIcon,
                 overrideSize = QuackButtonIconSize,
                 tint = QuackButtonIconTint,

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/gridLayout.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/gridLayout.kt
@@ -9,15 +9,19 @@ package team.duckie.quackquack.ui.component
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.PersistentList
+import team.duckie.quackquack.ui.modifier.quackClickable
 
 private val QuackGridLayoutContentPadding = PaddingValues(
     all = 0.dp,
@@ -71,62 +75,115 @@ public fun <T> QuackSimpleGridLayout(
     )
 }
 
-// /**
-//  * QuackHeaderGridLayout 을 구현합니다.
-//  *
-//  * GridLayout 중에 첫 아이템만 다른 아이템으로 사용해야하는 UI에 사용할 수 있습니다.
-//  *
-//  * @param columns
-//  * @param items
-//  * @param verticalSpace
-//  * @param horizontalSpace
-//  * @param horizontalPadding
-//  * @param itemContent
-//  * @param header
-//  */
-// @Composable
-// fun <T> QuackHeaderGridLayout(
-//     columns: Int,
-//     items: PersistentList<T>,
-//     verticalSpace: Dp,
-//     horizontalSpace: Dp,
-//     horizontalPadding: Dp = QuackGridHorizontalPadding,
-//     itemContent: @Composable (Int, T) -> Unit,
-//     header: @Composable () -> Unit,
-// ) {
-//
-//     val gridItems = listOf(items[0]) + items
-//
-//     LazyVerticalGrid(
-//         modifier = Modifier.padding(
-//             paddingValues = PaddingValues(
-//                 horizontal = horizontalPadding,
-//             )
-//         ),
-//         columns = GridCells.Fixed(
-//             count = columns
-//         ),
-//         content = {
-//             itemsIndexed(
-//                 items = gridItems,
-//             ) { index, item ->
-//                 QuackSimpleGridItem(
-//                     verticalSpace = verticalSpace,
-//                     horizontalSpace = horizontalSpace,
-//                     itemContent = {
-//                         itemContent(
-//                             index,
-//                             item,
-//                         )
-//                     },
-//                     header = header,
-//                     index = index,
-//                     size = gridItems.size,
-//                 )
-//             }
-//         },
-//     )
-// }
+/**
+ * [QuackHeaderGridLayout] 을 구현합니다.
+ *
+ * GridLayout 중에 첫 아이템만 다른 아이템으로 사용해야하는 UI에 사용할 수 있습니다.
+ *
+ * @param columns Grid가 몇 줄로 구성되어있는지에 대한 값
+ * @param items List로 사용할 아이템 데이터
+ * @param verticalSpace GridLayout 의 아이템간의 수직 간격
+ * @param horizontalSpace GridLayout 의 아이템간의 수평 간격
+ * @param contentPadding GridLayout 의 레이아웃 자체의 내부 패딩
+ * @param onClickHeader GridLayout의 헤더 아이템의 클릭 이벤트
+ * @param itemContent 구현할 아이템의 Composable 함수
+ * @param header 구현할 VerticalGridLayout의 첫 번째 아이템
+ */
+@Composable
+public fun <T> QuackHeaderGridLayout(
+    columns: Int,
+    items: PersistentList<T>,
+    verticalSpace: Dp = QuackVerticalSpacePadding,
+    horizontalSpace: Dp = QuackHorizontalSpacePadding,
+    contentPadding: PaddingValues = QuackGridLayoutContentPadding,
+    onClickHeader: () -> Unit,
+    itemContent: @Composable (Int, T) -> Unit,
+    header: @Composable () -> Unit,
+) {
+    val gridItems = listOf(items[0]) + items
+
+    LazyVerticalGrid(
+        contentPadding = contentPadding,
+        columns = GridCells.Fixed(
+            count = columns
+        ),
+        content = {
+            itemsIndexed(
+                items = gridItems,
+            ) { index, item ->
+                QuackSimpleGridItem(
+                    verticalSpace = verticalSpace,
+                    horizontalSpace = horizontalSpace,
+                    itemContent = {
+                        itemContent(
+                            index,
+                            item,
+                        )
+                    },
+                    header = header,
+                    index = index,
+                    size = gridItems.size,
+                    onClickHeader = onClickHeader,
+                )
+            }
+        },
+    )
+}
+
+/**
+ * [QuackHeaderGridLayout] 을 구현합니다.
+ *
+ * GridLayout 중에 첫 아이템만 다른 아이템으로 사용해야하는 UI에 사용할 수 있습니다.
+ *
+ * @param columns Grid가 몇 줄로 구성되어있는지에 대한 값
+ * @param items List로 사용할 아이템 데이터
+ * @param verticalSpace GridLayout 의 아이템간의 수직 간격
+ * @param horizontalSpace GridLayout 의 아이템간의 수평 간격
+ * @param contentPadding GridLayout 의 레이아웃 자체의 내부 패딩
+ * @param onClickFooter GridLayout의 마지막 아이템의 클릭 이벤트
+ * @param itemContent 구현할 아이템의 Composable 함수
+ * @param footer 구현할 VerticalGridLayout의 마지막 아이템
+ */
+@Composable
+public fun <T> QuackFooterGridLayout(
+    columns: Int,
+    items: PersistentList<T>,
+    verticalSpace: Dp = QuackVerticalSpacePadding,
+    horizontalSpace: Dp = QuackHorizontalSpacePadding,
+    contentPadding: PaddingValues = QuackGridLayoutContentPadding,
+    onClickFooter: () -> Unit,
+    itemContent: @Composable (Int, T) -> Unit,
+    footer: @Composable () -> Unit,
+) {
+    val gridItems = items + items[0]
+
+    LazyVerticalGrid(
+        contentPadding = contentPadding,
+        columns = GridCells.Fixed(
+            count = columns
+        ),
+        content = {
+            itemsIndexed(
+                items = gridItems,
+            ) { index, item ->
+                QuackSimpleGridItem(
+                    verticalSpace = verticalSpace,
+                    horizontalSpace = horizontalSpace,
+                    itemContent = {
+                        itemContent(
+                            index,
+                            item,
+                        )
+                    },
+                    footer = footer,
+                    index = index,
+                    size = gridItems.size,
+                    onClickFooter = onClickFooter,
+                )
+            }
+        },
+    )
+}
 
 /**
  * [QuackSimpleGridItem] 를 구현합니다
@@ -137,7 +194,9 @@ public fun <T> QuackSimpleGridLayout(
  * @param horizontalSpace 아이템간의 수평 간격
  * @param itemContent 일반적인 GridLayout 에서 사용되는 item @Composable 함수
  * @param footer 마지막 아이템으로 올 수 있는 @Composable 함수
+ * @param onClickFooter 마지막 아이템의 클릭 이벤트
  * @param header 첫 번째 아이템으로 올 수 있는 @Composable 함수
+ * @param onClickHeader 첫 번쨰 아이템의 클릭 이벤트
  */
 
 @Composable
@@ -148,19 +207,30 @@ private fun QuackSimpleGridItem(
     horizontalSpace: Dp,
     itemContent: @Composable () -> Unit,
     footer: (@Composable () -> Unit)? = null,
+    onClickFooter: (() -> Unit)? = null,
     header: (@Composable () -> Unit)? = null,
+    onClickHeader: ( () -> Unit)? = null,
 ) {
     Box(
-        modifier = Modifier.padding(
-            paddingValues = PaddingValues(
-                horizontal = horizontalSpace,
-                vertical = verticalSpace,
+        modifier = Modifier
+            .wrapContentWidth()
+            .aspectRatio(
+                ratio = 1f,
             )
-        ),
+            .padding(
+                paddingValues = PaddingValues(
+                    horizontal = horizontalSpace,
+                    vertical = verticalSpace,
+                )
+            ).quackClickable(
+                onClick = onClickFooter ?: onClickHeader,
+                rippleEnabled = true,
+            ),
+        contentAlignment = Alignment.Center,
     ) {
         if (index == 0 && header != null) {
             header()
-        } else if (index == size && footer != null) {
+        } else if (index == size - 1 && footer != null) {
             footer()
         } else {
             itemContent()

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/image.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/image.kt
@@ -37,9 +37,6 @@ import team.duckie.quackquack.ui.icon.QuackIcon
 import team.duckie.quackquack.ui.modifier.quackClickable
 import team.duckie.quackquack.ui.util.runIf
 
-private val QuackRoundImageShape = RoundedCornerShape(
-    size = 24.dp,
-)
 private val QuackRoundImageSize = DpSize(
     width = 72.dp,
     height = 72.dp,
@@ -48,6 +45,7 @@ private val QuackRoundImageSize = DpSize(
 /**
  * 이미지 혹은 [QuackIcon] 을 표시합니다.
  *
+ * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param src 표시할 리소스. 만약 null 이 들어온다면 리소스를 그리지 않습니다.
  * @param overrideSize 리소스의 크기를 지정합니다. null 이 들어오면 기본 크기로 표시합니다.
  * @param tint 아이콘에 적용할 틴트 값
@@ -57,6 +55,7 @@ private val QuackRoundImageSize = DpSize(
  */
 @Composable
 public fun QuackImage(
+    modifier: Modifier = Modifier,
     src: Any?,
     overrideSize: DpSize? = null,
     tint: QuackColor? = null,
@@ -64,7 +63,7 @@ public fun QuackImage(
     onClick: (() -> Unit)? = null,
     contentScale: ContentScale = ContentScale.Crop,
 ): Unit = QuackImageInternal(
-    modifier = Modifier.quackClickable(
+    modifier = modifier.quackClickable(
         rippleEnabled = rippleEnabled,
         onClick = onClick,
     ),
@@ -75,63 +74,21 @@ public fun QuackImage(
 )
 
 /**
- * 이미지 혹은 [QuackIcon] 을 표시합니다.
- *
- * @param src 표시할 리소스. 만약 null 이 들어온다면 리소스를 그리지 않습니다.
- * @param overrideSize 리소스의 크기를 지정합니다. null 이 들어오면 기본 크기로 표시합니다.
- * @param align [BoxScope] 내에서의 정렬
- * @param paddingProvider [PaddingValues] 를 제공할 람다
- * @param tint 아이콘에 적용할 틴트 값
- * @param rippleEnabled 이미지 클릭시 ripple 발생 여부
- * @param onClick 아이콘이 클릭됐을 때 실행할 람다식
- * @param contentScale 이미지에 들어갈 ContentScale 값
- */
-@Composable
-public fun BoxScope.QuackImage(
-    src: Any?,
-    overrideSize: DpSize? = null,
-    align: Alignment = Alignment.TopStart,
-    paddingProvider: () -> PaddingValues = { NoPadding },
-    tint: QuackColor? = null,
-    rippleEnabled: Boolean = true,
-    onClick: (() -> Unit)? = null,
-    contentScale: ContentScale = ContentScale.Crop,
-): Unit = QuackImageInternal(
-    modifier = Modifier
-        .quackClickable(
-            rippleEnabled = rippleEnabled,
-            onClick = onClick,
-        )
-        .align(
-            alignment = align,
-        )
-        .padding(
-            paddingValues = paddingProvider()
-        ),
-    src = src,
-    overrideSize = overrideSize,
-    tint = tint,
-    contentScale = contentScale,
-)
-
-
-/**
  * [QuackRoundImage] 를 구현합니다.
  *
- * 내부적으로 [QuackImageInternal] 를 사용하고
- * [Box]로 감싸 Shape 만 관여합니다.
- *
+ * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param src 표시할 이비지의 값
  * @param size 이미지의 사이즈 값
  */
 // TODO: 로딩 effect
 @Composable
 public fun QuackRoundImage(
+    modifier: Modifier = Modifier,
     src: Any?,
     size: DpSize = QuackRoundImageSize,
 ) {
     QuackImageInternal(
-        modifier = Modifier.clip(
+        modifier = modifier.clip(
             shape = QuackSquircle(),
         ),
         src = src,
@@ -139,40 +96,6 @@ public fun QuackRoundImage(
     )
 }
 
-/**
- * [QuackRoundImage] 를 구현합니다.
- *
- * 내부적으로 [QuackImageInternal] 를 사용하고
- * [Box]로 감싸 Shape만 관여합니다.
- *
- * @param src 표시할 이비지의 값
- * @param size 이미지의 사이즈 값
- * @param align [BoxScope] 내에서의 정렬
- * @param paddingProvider [PaddingValues] 를 제공할 람다
- */
-// TODO: 로딩 effect
-@Composable
-public fun BoxScope.QuackRoundImage(
-    src: Any?,
-    size: DpSize = QuackRoundImageSize,
-    align: Alignment = Alignment.TopStart,
-    paddingProvider: () -> PaddingValues = { NoPadding },
-) {
-    QuackImageInternal(
-        modifier = Modifier
-            .clip(
-                shape = QuackSquircle(),
-            )
-            .align(
-                alignment = align,
-            )
-            .padding(
-                paddingValues = paddingProvider()
-            ),
-        src = src,
-        overrideSize = size,
-    )
-}
 
 /**
  * [QuackImage] 를 실제로 그립니다. 내부에서 사용되는 컴포넌트이므로

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/selectableImage.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/selectableImage.kt
@@ -59,7 +59,7 @@ private val DeletableIconSize = DpSize(
  * @param isSelected 해당 이미지가 선택되었는지에 대한 상태값
  * @param image 이미지 resource
  * @param overrideSize 이미지의 길이는 화면에 따라 가변적이므로 넘겨받습니다
- * @param onClick 이미지가 선택되었을 때 발생하는 클릭 이벤트 -> 이미지 자체가 아니라 아이콘의 클릭 이벤트
+ * @param onClick 이미지가 선택되었을 때 발생하는 클릭 이벤트 -> 이미지 자체에 적용
  *
  * 클릭될 때마다 SelectedFilterBox 가 나타나게 됨
  *
@@ -95,12 +95,14 @@ public fun QuackSelectableImage(
     ) {
         QuackImageInternal(
             src = image,
-            modifier = sizeModifier,
+            modifier = sizeModifier.quackClickable(
+                rippleEnabled = true,
+                onClick = onClick,
+            ),
         )
         if (isSelected) SelectedFilterBox()
         QuackSelectedIcon(
             isSelected = isSelected,
-            onClick = onClick,
         )
     }
 }
@@ -109,12 +111,10 @@ public fun QuackSelectableImage(
  * QuackSelectedIcon 은 QuackSelectableImage 에서 사용되는 우상단 아이콘입니다.
  *
  * @param isSelected 아이콘이 선택되었는지에 대한 상태값, 어떤 아이콘을 보여줄지 결정합니다
- * @param onClick 아이콘 클릭시 발생하는 클릭 이벤트
  */
 @Composable
 private fun QuackSelectedIcon(
     isSelected: Boolean,
-    onClick: () -> Unit,
 ) {
     val selectableIcon = when (isSelected) {
         true -> QuackIcon.Checked
@@ -125,10 +125,6 @@ private fun QuackSelectedIcon(
         modifier = Modifier
             .padding(
                 paddingValues = ImagePadding,
-            )
-            .quackClickable(
-                rippleEnabled = false,
-                onClick = onClick,
             ),
         src = selectableIcon,
         overrideSize = SelectedIconSize,

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/topAppBar.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/topAppBar.kt
@@ -104,13 +104,13 @@ public fun QuackTopAppBar(
             ),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            this@Box.QuackImage(
+            QuackImage(
                 src = leadingIcon,
                 onClick = onClickLeadingIcon,
                 overrideSize = QuackTopAppBarIconSize,
             )
             if (headline != null) {
-                team.duckie.quackquack.ui.component.QuackHeadLine2(
+                QuackHeadLine2(
                     text = headline,
                 )
             }
@@ -125,7 +125,7 @@ public fun QuackTopAppBar(
             ),
         ) {
             if (secondTrailingIcon != null) {
-                this@Box.QuackImage(
+                QuackImage(
                     src = secondTrailingIcon,
                     onClick = onClickSecondTrailingIcon,
                     overrideSize = QuackTopAppBarIconSize,
@@ -133,7 +133,7 @@ public fun QuackTopAppBar(
             }
 
             if (trailingIcon != null) {
-                this@Box.QuackImage(
+                QuackImage(
                     src = trailingIcon,
                     onClick = onClickTrailingIcon,
                     overrideSize = QuackTopAppBarIconSize,
@@ -141,7 +141,7 @@ public fun QuackTopAppBar(
             }
 
             if (trailingText != null) {
-                team.duckie.quackquack.ui.component.QuackSubtitle2(
+                QuackSubtitle2(
                     text = trailingText,
                     onClick = onClickTrailingText,
                 )

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/typography.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/typography.kt
@@ -9,12 +9,8 @@
 
 package team.duckie.quackquack.ui.component
 
-import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.NonRestartableComposable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -23,7 +19,6 @@ import androidx.compose.ui.text.style.TextDecoration
 import kotlinx.collections.immutable.PersistentList
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.internal.QuackText
-import team.duckie.quackquack.ui.constant.NoPadding
 import team.duckie.quackquack.ui.modifier.quackClickable
 import team.duckie.quackquack.ui.textstyle.QuackTextStyle
 
@@ -33,6 +28,7 @@ import team.duckie.quackquack.ui.textstyle.QuackTextStyle
  * [QuackText] 에 [QuackTextStyle.HeadLine1] 스타일을 적용하여
  * 주어진 텍스트를 표시합니다.
  *
+ * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param text 표시할 텍스트
  * @param color 텍스트의 색상
  * @param align 텍스트 정렬
@@ -43,6 +39,7 @@ import team.duckie.quackquack.ui.textstyle.QuackTextStyle
 @Composable
 @NonRestartableComposable
 public fun QuackHeadLine1(
+    modifier: Modifier = Modifier,
     text: String,
     color: QuackColor = QuackColor.Black,
     align: TextAlign = TextAlign.Start,
@@ -50,7 +47,7 @@ public fun QuackHeadLine1(
     singleLine: Boolean = false,
     onClick: (() -> Unit)? = null,
 ): Unit = QuackText(
-    modifier = Modifier.quackClickable(
+    modifier = modifier.quackClickable(
         rippleEnabled = rippleEnabled,
         onClick = onClick,
     ),
@@ -63,55 +60,10 @@ public fun QuackHeadLine1(
 )
 
 /**
- * [QuackText] 에 [QuackTextStyle.HeadLine1] 스타일을 적용하여
- * 주어진 텍스트를 표시합니다.
- *
- * BoxScope 내에서 정렬, padding 을 설정할 수 있습니다.
- *
- * @param text 표시할 텍스트
- * @param color 텍스트의 색상
- * @param textAlign 텍스트 정렬
- * @param align [BoxScope] 내에서의 정렬
- * @param paddingProvider [PaddingValues] 를 제공할 람다
- * @param rippleEnabled 텍스트 클릭시 ripple 발생 여부
- * @param singleLine 텍스트를 한 줄만 사용할지 여부
- * @param onClick 텍스트이 클릭됐을 때 실행할 람다식
- */
-@Composable
-@NonRestartableComposable
-public fun BoxScope.QuackHeadLine1(
-    text: String,
-    color: QuackColor = QuackColor.Black,
-    textAlign: TextAlign = TextAlign.Start,
-    align: Alignment = Alignment.TopStart,
-    paddingProvider: () -> PaddingValues = { NoPadding },
-    rippleEnabled: Boolean = false,
-    singleLine: Boolean = false,
-    onClick: (() -> Unit)? = null,
-): Unit = QuackText(
-    modifier = Modifier
-        .quackClickable(
-            rippleEnabled = rippleEnabled,
-            onClick = onClick,
-        )
-        .align(
-            alignment = align,
-        )
-        .padding(
-            paddingValues = paddingProvider(),
-        ),
-    text = text,
-    style = QuackTextStyle.HeadLine1.change(
-        color = color,
-        textAlign = textAlign,
-    ),
-    singleLine = singleLine,
-)
-
-/**
  * [QuackText] 에 [QuackTextStyle.HeadLine2] 스타일을 적용하여
  * 주어진 텍스트를 표시합니다.
  *
+ * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param text 표시할 텍스트
  * @param color 텍스트의 색상
  * @param align 텍스트 정렬
@@ -121,6 +73,7 @@ public fun BoxScope.QuackHeadLine1(
  */
 @Composable
 public fun QuackHeadLine2(
+    modifier: Modifier = Modifier,
     text: String,
     color: QuackColor = QuackColor.Black,
     align: TextAlign = TextAlign.Start,
@@ -128,7 +81,7 @@ public fun QuackHeadLine2(
     singleLine: Boolean = false,
     onClick: (() -> Unit)? = null,
 ): Unit = QuackText(
-    modifier = Modifier.quackClickable(
+    modifier = modifier.quackClickable(
         rippleEnabled = rippleEnabled,
         onClick = onClick,
     ),
@@ -140,56 +93,12 @@ public fun QuackHeadLine2(
     singleLine = singleLine,
 )
 
-/**
- * [QuackText] 에 [QuackTextStyle.HeadLine2] 스타일을 적용하여
- * 주어진 텍스트를 표시합니다.
- *
- * BoxScope 내에서 정렬, padding 을 설정할 수 있습니다.
- *
- * @param text 표시할 텍스트
- * @param color 텍스트의 색상
- * @param textAlign 텍스트 정렬
- * @param align [BoxScope] 내에서의 정렬
- * @param paddingProvider [PaddingValues] 를 제공할 람다
- * @param rippleEnabled 텍스트 클릭시 ripple 발생 여부
- * @param singleLine 텍스트를 한 줄만 사용할지 여부
- * @param onClick 텍스트가 클릭됐을 때 실행할 람다식
- */
-@Composable
-@NonRestartableComposable
-public fun BoxScope.QuackHeadLine2(
-    text: String,
-    color: QuackColor = QuackColor.Black,
-    textAlign: TextAlign = TextAlign.Start,
-    align: Alignment = Alignment.TopStart,
-    paddingProvider: () -> PaddingValues = { NoPadding },
-    rippleEnabled: Boolean = false,
-    singleLine: Boolean = false,
-    onClick: (() -> Unit)? = null,
-): Unit = QuackText(
-    modifier = Modifier
-        .quackClickable(
-            rippleEnabled = rippleEnabled,
-            onClick = onClick,
-        )
-        .align(
-            alignment = align,
-        )
-        .padding(
-            paddingValues = paddingProvider(),
-        ),
-    text = text,
-    style = QuackTextStyle.HeadLine2.change(
-        color = color,
-        textAlign = textAlign,
-    ),
-    singleLine = singleLine,
-)
 
 /**
  * [QuackText] 에 [QuackTextStyle.Title1] 스타일을 적용하여
  * 주어진 텍스트를 표시합니다.
  *
+ * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param text 표시할 텍스트
  * @param color 텍스트의 색상
  * @param align 텍스트 정렬
@@ -199,6 +108,7 @@ public fun BoxScope.QuackHeadLine2(
  */
 @Composable
 public fun QuackTitle1(
+    modifier: Modifier = Modifier,
     text: String,
     color: QuackColor = QuackColor.Black,
     align: TextAlign = TextAlign.Start,
@@ -206,7 +116,7 @@ public fun QuackTitle1(
     singleLine: Boolean = false,
     onClick: (() -> Unit)? = null,
 ): Unit = QuackText(
-    modifier = Modifier.quackClickable(
+    modifier = modifier.quackClickable(
         rippleEnabled = rippleEnabled,
         onClick = onClick,
     ),
@@ -219,55 +129,10 @@ public fun QuackTitle1(
 )
 
 /**
- * [QuackText] 에 [QuackTextStyle.Title1] 스타일을 적용하여
- * 주어진 텍스트를 표시합니다.
- *
- * BoxScope 내에서 정렬, padding 을 설정할 수 있습니다.
- *
- * @param text 표시할 텍스트
- * @param color 텍스트의 색상
- * @param textAlign 텍스트 정렬
- * @param align [BoxScope] 내에서의 정렬
- * @param paddingProvider [PaddingValues] 를 제공할 람다
- * @param rippleEnabled 텍스트 클릭시 ripple 발생 여부
- * @param singleLine 텍스트를 한 줄만 사용할지 여부
- * @param onClick 텍스트가 클릭됐을 때 실행할 람다식
- */
-@Composable
-@NonRestartableComposable
-public fun BoxScope.QuackTitle1(
-    text: String,
-    color: QuackColor = QuackColor.Black,
-    textAlign: TextAlign = TextAlign.Start,
-    align: Alignment = Alignment.TopStart,
-    paddingProvider: () -> PaddingValues = { NoPadding },
-    rippleEnabled: Boolean = false,
-    singleLine: Boolean = false,
-    onClick: (() -> Unit)? = null,
-): Unit = QuackText(
-    modifier = Modifier
-        .quackClickable(
-            rippleEnabled = rippleEnabled,
-            onClick = onClick,
-        )
-        .align(
-            alignment = align,
-        )
-        .padding(
-            paddingValues = paddingProvider(),
-        ),
-    text = text,
-    style = QuackTextStyle.Title1.change(
-        color = color,
-        textAlign = textAlign,
-    ),
-    singleLine = singleLine,
-)
-
-/**
  * [QuackText] 에 [QuackTextStyle.Title2] 스타일을 적용하여
  * 주어진 텍스트를 표시합니다.
  *
+ * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param text 표시할 텍스트
  * @param color 텍스트의 색상
  * @param align 텍스트 정렬
@@ -277,6 +142,7 @@ public fun BoxScope.QuackTitle1(
  */
 @Composable
 public fun QuackTitle2(
+    modifier: Modifier = Modifier,
     text: String,
     color: QuackColor = QuackColor.Black,
     align: TextAlign = TextAlign.Start,
@@ -284,7 +150,7 @@ public fun QuackTitle2(
     singleLine: Boolean = false,
     onClick: (() -> Unit)? = null,
 ): Unit = QuackText(
-    modifier = Modifier.quackClickable(
+    modifier = modifier.quackClickable(
         rippleEnabled = rippleEnabled,
         onClick = onClick,
     ),
@@ -297,55 +163,10 @@ public fun QuackTitle2(
 )
 
 /**
- * [QuackText] 에 [QuackTextStyle.Title2] 스타일을 적용하여
- * 주어진 텍스트를 표시합니다.
- *
- * BoxScope 내에서 정렬, padding 을 설정할 수 있습니다.
- *
- * @param text 표시할 텍스트
- * @param color 텍스트의 색상
- * @param textAlign 텍스트 정렬
- * @param align [BoxScope] 내에서의 정렬
- * @param paddingProvider [PaddingValues] 를 제공할 람다
- * @param rippleEnabled 텍스트 클릭시 ripple 발생 여부
- * @param singleLine 텍스트를 한 줄만 사용할지 여부
- * @param onClick 텍스트가 클릭됐을 때 실행할 람다식
- */
-@Composable
-@NonRestartableComposable
-public fun BoxScope.QuackTitle2(
-    text: String,
-    color: QuackColor = QuackColor.Black,
-    textAlign: TextAlign = TextAlign.Start,
-    align: Alignment = Alignment.TopStart,
-    paddingProvider: () -> PaddingValues = { NoPadding },
-    rippleEnabled: Boolean = false,
-    singleLine: Boolean = false,
-    onClick: (() -> Unit)? = null,
-): Unit = QuackText(
-    modifier = Modifier
-        .quackClickable(
-            rippleEnabled = rippleEnabled,
-            onClick = onClick,
-        )
-        .align(
-            alignment = align,
-        )
-        .padding(
-            paddingValues = paddingProvider(),
-        ),
-    text = text,
-    style = QuackTextStyle.Title2.change(
-        color = color,
-        textAlign = textAlign,
-    ),
-    singleLine = singleLine,
-)
-
-/**
  * [QuackText] 에 [QuackTextStyle.Subtitle] 스타일을 적용하여
  * 주어진 텍스트를 표시합니다.
  *
+ * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param text 표시할 텍스트
  * @param color 텍스트의 색상
  * @param align 텍스트 정렬
@@ -355,6 +176,7 @@ public fun BoxScope.QuackTitle2(
  */
 @Composable
 public fun QuackSubtitle(
+    modifier: Modifier = Modifier,
     text: String,
     color: QuackColor = QuackColor.Black,
     align: TextAlign = TextAlign.Start,
@@ -362,7 +184,7 @@ public fun QuackSubtitle(
     singleLine: Boolean = false,
     onClick: (() -> Unit)? = null,
 ): Unit = QuackText(
-    modifier = Modifier.quackClickable(
+    modifier = modifier.quackClickable(
         rippleEnabled = rippleEnabled,
         onClick = onClick,
     ),
@@ -375,55 +197,10 @@ public fun QuackSubtitle(
 )
 
 /**
- * [QuackText] 에 [QuackTextStyle.Subtitle] 스타일을 적용하여
- * 주어진 텍스트를 표시합니다.
- *
- * BoxScope 내에서 정렬, padding 을 설정할 수 있습니다.
- *
- * @param text 표시할 텍스트
- * @param color 텍스트의 색상
- * @param textAlign 텍스트 정렬
- * @param align [BoxScope] 내에서의 정렬
- * @param paddingProvider [PaddingValues] 를 제공할 람다
- * @param rippleEnabled 텍스트 클릭시 ripple 발생 여부
- * @param singleLine 텍스트를 한 줄만 사용할지 여부
- * @param onClick 텍스트가 클릭됐을 때 실행할 람다식
- */
-@Composable
-@NonRestartableComposable
-public fun BoxScope.QuackSubtitle(
-    text: String,
-    color: QuackColor = QuackColor.Black,
-    textAlign: TextAlign = TextAlign.Start,
-    align: Alignment = Alignment.TopStart,
-    paddingProvider: () -> PaddingValues = { NoPadding },
-    rippleEnabled: Boolean = false,
-    singleLine: Boolean = false,
-    onClick: (() -> Unit)? = null,
-): Unit = QuackText(
-    modifier = Modifier
-        .quackClickable(
-            rippleEnabled = rippleEnabled,
-            onClick = onClick,
-        )
-        .align(
-            alignment = align,
-        )
-        .padding(
-            paddingValues = paddingProvider(),
-        ),
-    text = text,
-    style = QuackTextStyle.Subtitle.change(
-        color = color,
-        textAlign = textAlign,
-    ),
-    singleLine = singleLine,
-)
-
-/**
  * [QuackText] 에 [QuackTextStyle.Subtitle2] 스타일을 적용하여
  * 주어진 텍스트를 표시합니다.
  *
+ * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param text 표시할 텍스트
  * @param color 텍스트의 색상
  * @param align 텍스트 정렬
@@ -433,6 +210,7 @@ public fun BoxScope.QuackSubtitle(
  */
 @Composable
 public fun QuackSubtitle2(
+    modifier: Modifier = Modifier,
     text: String,
     color: QuackColor = QuackColor.Black,
     align: TextAlign = TextAlign.Start,
@@ -440,7 +218,7 @@ public fun QuackSubtitle2(
     singleLine: Boolean = false,
     onClick: (() -> Unit)? = null,
 ): Unit = QuackText(
-    modifier = Modifier.quackClickable(
+    modifier = modifier.quackClickable(
         rippleEnabled = rippleEnabled,
         onClick = onClick,
     ),
@@ -453,55 +231,10 @@ public fun QuackSubtitle2(
 )
 
 /**
- * [QuackText] 에 [QuackTextStyle.Subtitle2] 스타일을 적용하여
- * 주어진 텍스트를 표시합니다.
- *
- * BoxScope 내에서 정렬, padding 을 설정할 수 있습니다.
- *
- * @param text 표시할 텍스트
- * @param color 텍스트의 색상
- * @param textAlign 텍스트 정렬
- * @param align [BoxScope] 내에서의 정렬
- * @param paddingProvider [PaddingValues] 를 제공할 람다
- * @param rippleEnabled 텍스트 클릭시 ripple 발생 여부
- * @param singleLine 텍스트를 한 줄만 사용할지 여부
- * @param onClick 텍스트가 클릭됐을 때 실행할 람다식
- */
-@Composable
-@NonRestartableComposable
-public fun BoxScope.QuackSubtitle2(
-    text: String,
-    color: QuackColor = QuackColor.Black,
-    textAlign: TextAlign = TextAlign.Start,
-    align: Alignment = Alignment.TopStart,
-    paddingProvider: () -> PaddingValues = { NoPadding },
-    rippleEnabled: Boolean = false,
-    singleLine: Boolean = false,
-    onClick: (() -> Unit)? = null,
-): Unit = QuackText(
-    modifier = Modifier
-        .quackClickable(
-            rippleEnabled = rippleEnabled,
-            onClick = onClick,
-        )
-        .align(
-            alignment = align,
-        )
-        .padding(
-            paddingValues = paddingProvider(),
-        ),
-    text = text,
-    style = QuackTextStyle.Subtitle2.change(
-        color = color,
-        textAlign = textAlign,
-    ),
-    singleLine = singleLine,
-)
-
-/**
  * [QuackText] 에 [QuackTextStyle.Body1] 스타일을 적용하여
  * 주어진 텍스트를 표시합니다.
  *
+ * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param text 표시할 텍스트
  * @param color 텍스트의 색상
  * @param align 텍스트 정렬
@@ -511,6 +244,7 @@ public fun BoxScope.QuackSubtitle2(
  */
 @Composable
 public fun QuackBody1(
+    modifier: Modifier = Modifier,
     text: String,
     color: QuackColor = QuackColor.Black,
     align: TextAlign = TextAlign.Start,
@@ -518,7 +252,7 @@ public fun QuackBody1(
     singleLine: Boolean = false,
     onClick: (() -> Unit)? = null,
 ): Unit = QuackText(
-    modifier = Modifier.quackClickable(
+    modifier = modifier.quackClickable(
         rippleEnabled = rippleEnabled,
         onClick = onClick,
     ),
@@ -531,55 +265,10 @@ public fun QuackBody1(
 )
 
 /**
- * [QuackText] 에 [QuackTextStyle.Body1] 스타일을 적용하여
- * 주어진 텍스트를 표시합니다.
- *
- * BoxScope 내에서 정렬, padding 을 설정할 수 있습니다.
- *
- * @param text 표시할 텍스트
- * @param color 텍스트의 색상
- * @param textAlign 텍스트 정렬
- * @param align [BoxScope] 내에서의 정렬
- * @param paddingProvider [PaddingValues] 를 제공할 람다
- * @param rippleEnabled 텍스트 클릭시 ripple 발생 여부
- * @param singleLine 텍스트를 한 줄만 사용할지 여부
- * @param onClick 텍스트가 클릭됐을 때 실행할 람다식
- */
-@Composable
-@NonRestartableComposable
-public fun BoxScope.QuackBody1(
-    text: String,
-    color: QuackColor = QuackColor.Black,
-    textAlign: TextAlign = TextAlign.Start,
-    align: Alignment = Alignment.TopStart,
-    paddingProvider: () -> PaddingValues = { NoPadding },
-    rippleEnabled: Boolean = false,
-    singleLine: Boolean = false,
-    onClick: (() -> Unit)? = null,
-): Unit = QuackText(
-    modifier = Modifier
-        .quackClickable(
-            rippleEnabled = rippleEnabled,
-            onClick = onClick,
-        )
-        .align(
-            alignment = align,
-        )
-        .padding(
-            paddingValues = paddingProvider(),
-        ),
-    text = text,
-    style = QuackTextStyle.Body1.change(
-        color = color,
-        textAlign = textAlign,
-    ),
-    singleLine = singleLine,
-)
-
-/**
  * [QuackText] 에 [QuackTextStyle.Body2] 스타일을 적용하여
  * 주어진 텍스트를 표시합니다.
  *
+ * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param text 표시할 텍스트
  * @param color 텍스트의 색상
  * @param align 텍스트 정렬
@@ -589,6 +278,7 @@ public fun BoxScope.QuackBody1(
  */
 @Composable
 public fun QuackBody2(
+    modifier: Modifier = Modifier,
     text: String,
     color: QuackColor = QuackColor.Black,
     align: TextAlign = TextAlign.Start,
@@ -596,7 +286,7 @@ public fun QuackBody2(
     onClick: (() -> Unit)? = null,
     singleLine: Boolean = false,
 ): Unit = QuackText(
-    modifier = Modifier.quackClickable(
+    modifier = modifier.quackClickable(
         rippleEnabled = rippleEnabled,
         onClick = onClick,
     ),
@@ -609,55 +299,10 @@ public fun QuackBody2(
 )
 
 /**
- * [QuackText] 에 [QuackTextStyle.Body2] 스타일을 적용하여
- * 주어진 텍스트를 표시합니다.
- *
- * BoxScope 내에서 정렬, padding 을 설정할 수 있습니다.
- *
- * @param text 표시할 텍스트
- * @param color 텍스트의 색상
- * @param textAlign 텍스트 정렬
- * @param align [BoxScope] 내에서의 정렬
- * @param paddingProvider [PaddingValues] 를 제공할 람다
- * @param rippleEnabled 텍스트 클릭시 ripple 발생 여부
- * @param singleLine 텍스트를 한 줄만 사용할지 여부
- * @param onClick 텍스트가 클릭됐을 때 실행할 람다식
- */
-@Composable
-@NonRestartableComposable
-public fun BoxScope.QuackBody2(
-    text: String,
-    color: QuackColor = QuackColor.Black,
-    textAlign: TextAlign = TextAlign.Start,
-    align: Alignment = Alignment.TopStart,
-    paddingProvider: () -> PaddingValues = { NoPadding },
-    rippleEnabled: Boolean = false,
-    singleLine: Boolean = false,
-    onClick: (() -> Unit)? = null,
-): Unit = QuackText(
-    modifier = Modifier
-        .quackClickable(
-            rippleEnabled = rippleEnabled,
-            onClick = onClick,
-        )
-        .align(
-            alignment = align,
-        )
-        .padding(
-            paddingValues = paddingProvider(),
-        ),
-    text = text,
-    style = QuackTextStyle.Body2.change(
-        color = color,
-        textAlign = textAlign,
-    ),
-    singleLine = singleLine,
-)
-
-/**
  * [QuackText] 에 [QuackTextStyle.Body3] 스타일을 적용하여
  * 주어진 텍스트를 표시합니다.
  *
+ * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param text 표시할 텍스트
  * @param color 텍스트의 색상
  * @param align 텍스트 정렬
@@ -667,6 +312,7 @@ public fun BoxScope.QuackBody2(
  */
 @Composable
 public fun QuackBody3(
+    modifier: Modifier = Modifier,
     text: String,
     color: QuackColor = QuackColor.Black,
     align: TextAlign = TextAlign.Start,
@@ -674,7 +320,7 @@ public fun QuackBody3(
     onClick: (() -> Unit)? = null,
     singleLine: Boolean = false,
 ): Unit = QuackText(
-    modifier = Modifier.quackClickable(
+    modifier = modifier.quackClickable(
         rippleEnabled = rippleEnabled,
         onClick = onClick,
     ),
@@ -687,55 +333,10 @@ public fun QuackBody3(
 )
 
 /**
- * [QuackText] 에 [QuackTextStyle.Body3] 스타일을 적용하여
- * 주어진 텍스트를 표시합니다.
- *
- * BoxScope 내에서 정렬, padding 을 설정할 수 있습니다.
- *
- * @param text 표시할 텍스트
- * @param color 텍스트의 색상
- * @param textAlign 텍스트 정렬
- * @param align [BoxScope] 내에서의 정렬
- * @param paddingProvider [PaddingValues] 를 제공할 람다
- * @param rippleEnabled 텍스트 클릭시 ripple 발생 여부
- * @param singleLine 텍스트를 한 줄만 사용할지 여부
- * @param onClick 텍스트가 클릭됐을 때 실행할 람다식
- */
-@Composable
-@NonRestartableComposable
-public fun BoxScope.QuackBody3(
-    text: String,
-    color: QuackColor = QuackColor.Black,
-    textAlign: TextAlign = TextAlign.Start,
-    align: Alignment = Alignment.TopStart,
-    paddingProvider: () -> PaddingValues = { NoPadding },
-    rippleEnabled: Boolean = false,
-    singleLine: Boolean = false,
-    onClick: (() -> Unit)? = null,
-): Unit = QuackText(
-    modifier = Modifier
-        .quackClickable(
-            rippleEnabled = rippleEnabled,
-            onClick = onClick,
-        )
-        .align(
-            alignment = align,
-        )
-        .padding(
-            paddingValues = paddingProvider(),
-        ),
-    text = text,
-    style = QuackTextStyle.Body3.change(
-        color = color,
-        textAlign = textAlign,
-    ),
-    singleLine = singleLine,
-)
-
-/**
  * [QuackHeadLine2] 에 원하는 부분에 원하는 색깔로 강조하여
  * 주어진 텍스트를 표시합니다.
  *
+ * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param text 표시할 텍스트
  * @param highlightTextList 강조할 텍스트 리스트
  * @param highlightColor 강조할 Text 의 색깔
@@ -748,6 +349,7 @@ public fun BoxScope.QuackBody3(
 @Composable
 @NonRestartableComposable
 public fun QuackHighlightHeadLine2(
+    modifier: Modifier = Modifier,
     text: String,
     highlightTextList: PersistentList<String>,
     highlightColor: QuackColor = QuackColor.DuckieOrange,
@@ -758,7 +360,7 @@ public fun QuackHighlightHeadLine2(
     onClick: (() -> Unit)? = null,
 ) {
     QuackText(
-        modifier = Modifier.quackClickable(
+        modifier = modifier.quackClickable(
             rippleEnabled = rippleEnabled,
             onClick = onClick,
         ),
@@ -787,74 +389,10 @@ public fun QuackHighlightHeadLine2(
 }
 
 /**
- * [QuackHeadLine2] 에 원하는 부분에 원하는 색깔로 강조하여
- * 주어진 텍스트를 표시합니다.
- *
- * @param text 표시할 텍스트
- * @param highlightTextList 강조할 텍스트 리스트
- * @param highlightColor 강조할 Text 의 색깔
- * @param color 텍스트의 색상
- * @param textAlign 텍스트 정렬
- * @param align [BoxScope] 내에서의 정렬
- * @param paddingProvider [PaddingValues] 를 제공할 람다
- * @param singleLine 텍스트를 한 줄로 사용할지 여부
- * @param rippleEnabled 텍스트 클릭시 ripple 발생 여부
- * @param onClick 텍스트이 클릭됐을 때 실행할 람다식
- */
-@Composable
-@NonRestartableComposable
-public fun BoxScope.QuackHighlightHeadLine2(
-    text: String,
-    highlightTextList: PersistentList<String>,
-    highlightColor: QuackColor = QuackColor.DuckieOrange,
-    color: QuackColor = QuackColor.Black,
-    textAlign: TextAlign = TextAlign.Start,
-    align: Alignment = Alignment.TopStart,
-    paddingProvider: () -> PaddingValues = { NoPadding },
-    singleLine: Boolean = false,
-    rippleEnabled: Boolean = false,
-    onClick: (() -> Unit)? = null,
-) {
-    QuackText(
-        modifier = Modifier
-            .quackClickable(
-                rippleEnabled = rippleEnabled,
-                onClick = onClick,
-            )
-            .align(
-                alignment = align,
-            )
-            .padding(
-                paddingValues = paddingProvider(),
-            ),
-        text = buildAnnotatedString {
-            append(text)
-            highlightTextList.forEach { highlightText ->
-                val highlightStartIndex = text.indexOf(
-                    string = highlightText
-                )
-                addStyle(
-                    style = SpanStyle(
-                        color = highlightColor.composeColor,
-                        textDecoration = TextDecoration.Underline,
-                    ),
-                    start = highlightStartIndex,
-                    end = highlightStartIndex + highlightText.length,
-                )
-            }
-        },
-        style = QuackTextStyle.HeadLine2.change(
-            color = color,
-            textAlign = textAlign,
-        ),
-        singleLine = singleLine,
-    )
-}
-
-/**
  * [QuackHighlightBody3] 에 원하는 부분에 원하는 색깔로 강조하여
  * 주어진 텍스트를 표시합니다.
  *
+ * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param text 표시할 텍스트
  * @param highlightTextList 강조할 텍스트 리스트들
  * @param highlightColor 강조할 Text 의 색깔
@@ -867,6 +405,7 @@ public fun BoxScope.QuackHighlightHeadLine2(
 @Composable
 @NonRestartableComposable
 public fun QuackHighlightBody3(
+    modifier: Modifier = Modifier,
     text: String,
     highlightTextList: PersistentList<String>,
     highlightColor: QuackColor = QuackColor.DuckieOrange,
@@ -878,7 +417,7 @@ public fun QuackHighlightBody3(
 ) {
 
     QuackText(
-        modifier = Modifier.quackClickable(
+        modifier = modifier.quackClickable(
             rippleEnabled = rippleEnabled,
             onClick = onClick,
         ),
@@ -901,71 +440,6 @@ public fun QuackHighlightBody3(
         style = QuackTextStyle.Body3.change(
             color = color,
             textAlign = align,
-        ),
-        singleLine = singleLine,
-    )
-}
-
-/**
- * [QuackHighlightBody3] 에 원하는 부분에 원하는 색깔로 강조하여
- * 주어진 텍스트를 표시합니다.
- *
- * @param text 표시할 텍스트
- * @param highlightTextList 강조할 텍스트 리스트
- * @param highlightColor 강조할 Text 의 색깔
- * @param color 텍스트의 색상
- * @param textAlign 텍스트 정렬
- * @param align [BoxScope] 내에서의 정렬
- * @param paddingProvider [PaddingValues] 를 제공할 람다
- * @param singleLine 텍스트를 한 줄로 사용할지 여부
- * @param rippleEnabled 텍스트 클릭시 ripple 발생 여부
- * @param onClick 텍스트이 클릭됐을 때 실행할 람다식
- */
-@Composable
-@NonRestartableComposable
-public fun BoxScope.QuackHighlightHeadLine3(
-    text: String,
-    highlightTextList: PersistentList<String>,
-    highlightColor: QuackColor = QuackColor.DuckieOrange,
-    color: QuackColor = QuackColor.Black,
-    textAlign: TextAlign = TextAlign.Start,
-    align: Alignment = Alignment.TopStart,
-    paddingProvider: () -> PaddingValues = { NoPadding },
-    singleLine: Boolean = false,
-    rippleEnabled: Boolean = false,
-    onClick: (() -> Unit)? = null,
-) {
-    QuackText(
-        modifier = Modifier
-            .quackClickable(
-                rippleEnabled = rippleEnabled,
-                onClick = onClick,
-            )
-            .align(
-                alignment = align,
-            )
-            .padding(
-                paddingValues = paddingProvider(),
-            ),
-        text = buildAnnotatedString {
-            append(text)
-            highlightTextList.forEach { highlightText ->
-                val highlightStartIndex = text.indexOf(
-                    string = highlightText
-                )
-                addStyle(
-                    style = SpanStyle(
-                        color = highlightColor.composeColor,
-                        textDecoration = TextDecoration.Underline,
-                    ),
-                    start = highlightStartIndex,
-                    end = highlightStartIndex + highlightText.length,
-                )
-            }
-        },
-        style = QuackTextStyle.Body3.change(
-            color = color,
-            textAlign = textAlign,
         ),
         singleLine = singleLine,
     )

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/typography.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/typography.kt
@@ -14,8 +14,10 @@ import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.sp
 import kotlinx.collections.immutable.PersistentList
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.internal.QuackText
@@ -333,13 +335,13 @@ public fun QuackBody3(
 )
 
 /**
- * [QuackHeadLine2] 에 원하는 부분에 원하는 색깔로 강조하여
+ * [QuackHeadLine2] 에 원하는 부분에 원하는 색깔과 밑줄로 강조하여
  * 주어진 텍스트를 표시합니다.
  *
  * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param text 표시할 텍스트
- * @param highlightTextList 강조할 텍스트 리스트
- * @param highlightColor 강조할 Text 의 색깔
+ * @param underlineText 강조할 텍스트 리스트
+ * @param underlineTextColor 강조할 Text 의 색깔
  * @param color 텍스트의 색상
  * @param align 텍스트 정렬
  * @param singleLine 텍스트를 한 줄로 사용할지 여부
@@ -348,11 +350,11 @@ public fun QuackBody3(
  */
 @Composable
 @NonRestartableComposable
-public fun QuackHighlightHeadLine2(
+public fun QuackUnderlineHeadLine2(
     modifier: Modifier = Modifier,
     text: String,
-    highlightTextList: PersistentList<String>,
-    highlightColor: QuackColor = QuackColor.DuckieOrange,
+    underlineText: PersistentList<String>,
+    underlineTextColor: QuackColor = QuackColor.DuckieOrange,
     color: QuackColor = QuackColor.Black,
     align: TextAlign = TextAlign.Start,
     singleLine: Boolean = false,
@@ -366,13 +368,13 @@ public fun QuackHighlightHeadLine2(
         ),
         text = buildAnnotatedString {
             append(text)
-            highlightTextList.forEach { highlightText ->
+            underlineText.forEach { highlightText ->
                 val highlightStartIndex = text.indexOf(
                     string = highlightText
                 )
                 addStyle(
                     style = SpanStyle(
-                        color = highlightColor.composeColor,
+                        color = underlineTextColor.composeColor,
                         textDecoration = TextDecoration.Underline,
                     ),
                     start = highlightStartIndex,
@@ -389,13 +391,13 @@ public fun QuackHighlightHeadLine2(
 }
 
 /**
- * [QuackHighlightBody3] 에 원하는 부분에 원하는 색깔로 강조하여
+ * [QuackUnderlineBody3] 에 원하는 부분에 원하는 색깔과 밑줄로 강조하여
  * 주어진 텍스트를 표시합니다.
  *
  * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
  * @param text 표시할 텍스트
- * @param highlightTextList 강조할 텍스트 리스트들
- * @param highlightColor 강조할 Text 의 색깔
+ * @param underlineText 강조할 텍스트 리스트들
+ * @param undelineTextColor 강조할 Text 의 색깔
  * @param color 텍스트의 색상
  * @param align 텍스트 정렬
  * @param rippleEnabled 텍스트 클릭시 ripple 발생 여부
@@ -404,11 +406,11 @@ public fun QuackHighlightHeadLine2(
  */
 @Composable
 @NonRestartableComposable
-public fun QuackHighlightBody3(
+public fun QuackUnderlineBody3(
     modifier: Modifier = Modifier,
     text: String,
-    highlightTextList: PersistentList<String>,
-    highlightColor: QuackColor = QuackColor.DuckieOrange,
+    underlineText: PersistentList<String>,
+    undelineTextColor: QuackColor = QuackColor.DuckieOrange,
     color: QuackColor = QuackColor.Black,
     align: TextAlign = TextAlign.Start,
     rippleEnabled: Boolean = false,
@@ -423,13 +425,13 @@ public fun QuackHighlightBody3(
         ),
         text = buildAnnotatedString {
             append(text)
-            highlightTextList.forEach { highlightText ->
+            underlineText.forEach { highlightText ->
                 val highlightStartIndex = text.indexOf(
                     string = highlightText
                 )
                 addStyle(
                     style = SpanStyle(
-                        color = highlightColor.composeColor,
+                        color = undelineTextColor.composeColor,
                         textDecoration = TextDecoration.Underline,
                     ),
                     start = highlightStartIndex,
@@ -438,6 +440,61 @@ public fun QuackHighlightBody3(
             }
         },
         style = QuackTextStyle.Body3.change(
+            color = color,
+            textAlign = align,
+        ),
+        singleLine = singleLine,
+    )
+}
+
+/**
+ * [QuackUnderlineBody3] 에 원하는 부분에 원하는 색깔과 밑줄로 강조하여
+ * 주어진 텍스트를 표시합니다.
+ *
+ * @param modifier 컴포넌트의 Modifier => align과 padding등을 위하여 열어놨습니다.
+ * @param text 표시할 텍스트
+ * @param highlightText 강조할 텍스트 리스트들
+ * @param color 텍스트의 색상
+ * @param align 텍스트 정렬
+ * @param rippleEnabled 텍스트 클릭시 ripple 발생 여부
+ * @param onClick 텍스트이 클릭됐을 때 실행할 람다식
+ * @param singleLine 텍스트를 한 줄로 사용할지 여부
+ */
+@Composable
+@NonRestartableComposable
+public fun QuackHighlightBody1(
+    modifier: Modifier = Modifier,
+    text: String,
+    highlightText: PersistentList<String>,
+    color: QuackColor = QuackColor.Black,
+    align: TextAlign = TextAlign.Start,
+    rippleEnabled: Boolean = false,
+    onClick: (() -> Unit)? = null,
+    singleLine: Boolean = false,
+) {
+
+    QuackText(
+        modifier = modifier.quackClickable(
+            rippleEnabled = rippleEnabled,
+            onClick = onClick,
+        ),
+        text = buildAnnotatedString {
+            append(text)
+            highlightText.forEach { highlightText ->
+                val highlightStartIndex = text.indexOf(
+                    string = highlightText
+                )
+                addStyle(
+                    style = SpanStyle(
+                        fontWeight = FontWeight.SemiBold,
+                        letterSpacing = 0.sp,
+                    ),
+                    start = highlightStartIndex,
+                    end = highlightStartIndex + highlightText.length,
+                )
+            }
+        },
+        style = QuackTextStyle.Body1.change(
             color = color,
             textAlign = align,
         ),


### PR DESCRIPTION
## Overview (Required)

- 일부 컴포넌트 padding과 align을 위해 Modifier 파리미터로 제공
- GridLayout 사용시 Header와 Footer 아이템 사용 가능
- QuackSelectableImage 클릭 범위 변경
- QuackHighlight와 QuackUnderlie Typography 구분해서 구현

