### PR TITLE
chore: 버전 1.2.2 로 상향

### DIFF
--- a/quackquack-version/ui-components.txt
+++ b/quackquack-version/ui-components.txt
@@ -1,3 +1,3 @@
 major=1
 minor=2
-patch=1
+patch=2


### PR DESCRIPTION
## Overview (Required)

- ui-components 의 버전을 1.2.2 로 상향하였습니다.
