### PR TITLE
QuackMultiLineTagRow 및 디자인 디테일

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ compose-constraintlayout = { module = "androidx.constraintlayout:constraintlayou
 compose-coil = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 compose-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose-core" } # debugImplementation
 compose-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-core" }
+compose-accompanist-flowlayout = { module = "com.google.accompanist:accompanist-flowlayout", version.ref = "accompanist" }
 
 customview-poolingcontainer = { module = "androidx.customview:customview-poolingcontainer", version.ref = "customview-poolingcontainer" } # debugImplementation
 

--- a/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/TagPlayground.kt
+++ b/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/TagPlayground.kt
@@ -21,6 +21,7 @@ import team.duckie.quackquack.playground.base.PlaygroundSection
 import team.duckie.quackquack.playground.theme.PlaygroundTheme
 import team.duckie.quackquack.ui.component.QuackGrayscaleTag
 import team.duckie.quackquack.ui.component.QuackIconTag
+import team.duckie.quackquack.ui.component.QuackMultiLineTagRow
 import team.duckie.quackquack.ui.component.QuackRowTag
 import team.duckie.quackquack.ui.component.QuackSingleRowTag
 import team.duckie.quackquack.ui.component.QuackTag
@@ -35,7 +36,8 @@ class TagPlayground : BaseActivity() {
         "QuackTagRowDemo" to { QuackTagRowDemo() },
         "QuackTagScrollableRowDemo" to { QuackSingleRowTag() },
         "QuackSingleRowTag" to { QuackSingleRowTag() },
-        "QuackSingleRowTagDeletable" to { QuackSingleRowTagDeletable() }
+        "QuackSingleRowTagDeletable" to { QuackSingleRowTagDeletable() },
+        "QuackMultiTagRow" to { QuackMultiTagRowDemo() }
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -194,4 +196,36 @@ fun QuackSingleRowTagDeletable() {
         },
         iconResource = QuackIcon.Close,
     )
+}
+
+@Composable
+fun QuackMultiTagRowDemo() {
+
+    val list = remember {
+        mutableStateOf(
+            listOf(
+                "마블",
+                "덕키",
+                "픽사",
+                "아바타",
+                "탑건",
+                "무지개양말",
+                "피드내용",
+                "추가한태그",
+                "태그",
+                "피드",
+                "다른유저",
+                "제목",
+            )
+        )
+    }
+    QuackMultiLineTagRow(
+        title = "추가한 태그",
+        items = list.value,
+        icon = QuackIcon.Close,
+        onClickIcon = { index ->
+            list.value = list.value - list.value[index]
+        },
+    )
+
 }

--- a/ui-components/build.gradle.kts
+++ b/ui-components/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementations(
         libs.compose.coil,
         libs.compose.material,
+        libs.compose.accompanist.flowlayout,
         // projects.uxWritingModel,
     )
     api(libs.kotlin.collections.immutable)

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/gridLayout.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/gridLayout.kt
@@ -100,6 +100,7 @@ public fun <T> QuackHeaderGridLayout(
     itemContent: @Composable (Int, T) -> Unit,
     header: @Composable () -> Unit,
 ) {
+    if ( items.isEmpty()) return
     val gridItems = listOf(items[0]) + items
 
     LazyVerticalGrid(
@@ -155,6 +156,7 @@ public fun <T> QuackFooterGridLayout(
     itemContent: @Composable (Int, T) -> Unit,
     footer: @Composable () -> Unit,
 ) {
+    if ( items.isEmpty()) return
     val gridItems = items + items[0]
 
     LazyVerticalGrid(
@@ -214,9 +216,6 @@ private fun QuackSimpleGridItem(
     Box(
         modifier = Modifier
             .wrapContentWidth()
-            .aspectRatio(
-                ratio = 1f,
-            )
             .padding(
                 paddingValues = PaddingValues(
                     horizontal = horizontalSpace,

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/tag.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/tag.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.flowlayout.FlowRow
 import kotlinx.collections.immutable.ImmutableCollection
@@ -534,6 +535,7 @@ public fun QuackMultiLineTagRow(
     title: String? = null,
     items: List<String>,
     icon: QuackIcon? = null,
+    mainAxisSpacing: Dp = QuackTagContentSpace,
     onClickIcon: ((
         index: Int,
     ) -> Unit)? = null,
@@ -552,7 +554,7 @@ public fun QuackMultiLineTagRow(
             )
         }
         FlowRow(
-            mainAxisSpacing = 8.dp
+            mainAxisSpacing = mainAxisSpacing,
         ) {
             items.forEachIndexed { index, text ->
                 when (icon) {

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/tag.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/tag.kt
@@ -529,6 +529,14 @@ public fun QuackSingleRowTag(
 
 /**
  * [QuackMultiLineTagRow] 를 구현합니다.
+ *
+ * Tag 자체를 넘치지 않는한 우측으로 계속 쌓는 UI가 필요할 떄 사용합니다.
+ *
+ * @param title 태그 컴포넌트 위의 표시되는 텍스트
+ * @param items 태그에 사용될 텍스트들
+ * @param icon 태그에 사용될 아이콘
+ * @param mainAxisSpacing 태그들 사이의 간격
+ * @param onClickIcon 아이콘 클릭 이벤트
  */
 @Composable
 public fun QuackMultiLineTagRow(

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/tag.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/tag.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.google.accompanist.flowlayout.FlowRow
 import kotlinx.collections.immutable.ImmutableCollection
 import kotlinx.collections.immutable.PersistentList
 import team.duckie.quackquack.ui.animation.QuackAnimationSpec
@@ -518,6 +519,53 @@ public fun QuackSingleRowTag(
                         isSelected = itemsSelection[index], // assertion 은 함수 초반부에서 진행됨
                         onClick = onClickValue,
                         text = item,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * [QuackMultiLineTagRow] 를 구현합니다.
+ */
+@Composable
+public fun QuackMultiLineTagRow(
+    title: String? = null,
+    items: List<String>,
+    icon: QuackIcon? = null,
+    onClickIcon: ((
+        index: Int,
+    ) -> Unit)? = null,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight(),
+    ) {
+        if (title != null) {
+            QuackTitle2(
+                modifier = Modifier.padding(
+                    bottom = QuackTagRowTitleSpace,
+                ),
+                text = title,
+            )
+        }
+        FlowRow(
+            mainAxisSpacing = 8.dp
+        ) {
+            items.forEachIndexed { index, text ->
+                when (icon) {
+                    null -> {
+                        QuackTag(text = text, isSelected = false)
+                    }
+                    else -> QuackIconTag(
+                        text = text,
+                        icon = icon,
+                        isSelected = false,
+                        onClickIcon = {
+                            onClickIcon?.invoke(index)
+                        }
                     )
                 }
             }

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/topAppBar.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/topAppBar.kt
@@ -65,6 +65,7 @@ public fun QuackTopAppBar(
     trailingIcon: QuackIcon? = null,
     secondTrailingIcon: QuackIcon? = null,
     trailingText: String? = null,
+    trailingTextColor: QuackColor = QuackColor.Black,
     headline: String? = null,
     centerContent: (@Composable () -> Unit)? = null,
     onClickLeadingIcon: (() -> Unit)? = null,
@@ -144,6 +145,8 @@ public fun QuackTopAppBar(
                 QuackSubtitle2(
                     text = trailingText,
                     onClick = onClickTrailingText,
+                    rippleEnabled = true,
+                    color = trailingTextColor,
                 )
             }
         }


### PR DESCRIPTION
## Overview (Required)

- FlowRow를 이용하여 Tag 추가하는 화면에서 사용되는 QuackMultiLineTagRow를 구현했습니다.
- TopAppBar의 TrailingText도 색깔을 입력받을 수 있습니다.
- GridLayout에서 발생하는 에러를 수정했습니다

