### PR TITLE
QuackIconTextToggle, QuackMultiLineTagRow 수정

### DIFF
--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/tag.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/tag.kt
@@ -54,7 +54,6 @@ private val QuackTagRowFlowContentSpace = 8.dp
 private val QuackTagContentSpace = 8.dp
 private val QuackTagBorderWidth = 1.dp
 private val QuackTagHorizontalPadding = 8.dp
-private val QuackTagVerticalSpace = 8.dp
 
 private val QuackTagPadding = PaddingValues(
     horizontal = 12.dp,
@@ -553,7 +552,6 @@ public fun QuackMultiLineTagRow(
     items: List<String>,
     icon: QuackIcon? = null,
     mainAxisSpacing: Dp = QuackTagContentSpace,
-    crossAxisSpacing: Dp = QuackTagVerticalSpace,
     onClickIcon: ((
         index: Int,
     ) -> Unit)? = null,
@@ -573,7 +571,6 @@ public fun QuackMultiLineTagRow(
         }
         FlowRow(
             mainAxisSpacing = mainAxisSpacing,
-            crossAxisSpacing = crossAxisSpacing,
         ) {
             items.forEachIndexed { index, text ->
                 when (icon) {

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/tag.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/tag.kt
@@ -54,6 +54,7 @@ private val QuackTagRowFlowContentSpace = 8.dp
 private val QuackTagContentSpace = 8.dp
 private val QuackTagBorderWidth = 1.dp
 private val QuackTagHorizontalPadding = 8.dp
+private val QuackTagVerticalSpace = 8.dp
 
 private val QuackTagPadding = PaddingValues(
     horizontal = 12.dp,
@@ -552,6 +553,7 @@ public fun QuackMultiLineTagRow(
     items: List<String>,
     icon: QuackIcon? = null,
     mainAxisSpacing: Dp = QuackTagContentSpace,
+    crossAxisSpacing: Dp = QuackTagVerticalSpace,
     onClickIcon: ((
         index: Int,
     ) -> Unit)? = null,
@@ -571,6 +573,7 @@ public fun QuackMultiLineTagRow(
         }
         FlowRow(
             mainAxisSpacing = mainAxisSpacing,
+            crossAxisSpacing = crossAxisSpacing,
         ) {
             items.forEachIndexed { index, text ->
                 when (icon) {

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/toggle.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/toggle.kt
@@ -48,6 +48,7 @@ private const val BoxOutDuration = 100
 private val RoundCheckboxSize = 28.dp
 private val SquareCheckboxSize = 24.dp
 private val IconSize = 24.dp
+private val SmallIconSize = 18.dp
 private val StrokeWidth = 1.5.dp
 
 private val QuackIconTextToggleSpacing = 4.dp
@@ -167,6 +168,7 @@ public fun QuackIconTextToggle(
             uncheckedIcon = uncheckedIcon,
             checked = checked,
             onToggle = onToggle,
+            size = SmallIconSize,
         )
         QuackBody2(
             text = text,
@@ -214,11 +216,16 @@ private fun QuackBasicIconToggle(
     uncheckedIcon: QuackIcon,
     checked: Boolean,
     onToggle: () -> Unit,
+    size: Dp = IconSize,
 ) = QuackImage(
     overrideSize = DpSize(
-        width = IconSize,
-        height = IconSize,
+        width = size,
+        height = size,
     ),
+    tint = when(checkedIcon != null && checked){
+        true -> QuackColor.DuckieOrange
+        false -> QuackColor.Gray1
+    },
     src = when (checkedIcon != null && checked) {
         true -> checkedIcon
         else -> uncheckedIcon


### PR DESCRIPTION
## Overview (Required)
QuackIconText의 size와 tint를 수정하였습니다
QuackMultiLineTagRow의 vertical spacing을 수정하였습니다.
## Screenshot
변경 전
![image](https://user-images.githubusercontent.com/70064912/196403704-8870ab91-8127-48db-8b77-3e78b9554d12.png)
변경 후
![image](https://user-images.githubusercontent.com/70064912/196403649-a03aa777-e426-40be-b750-18d4d307bb5b.png)
변경 전
![image](https://user-images.githubusercontent.com/70064912/196409981-22bdc32b-84ac-4736-8946-3a988e2221ca.png)

변경 후
![image](https://user-images.githubusercontent.com/70064912/196409859-52bc7676-805c-4c61-a5b0-0909c4d9c91f.png)